### PR TITLE
add: Color log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - db
       - chrome
       - redis
+    platform: linux/x86_64
   db:
     image: mysql:8.0.33
     environment:
@@ -27,11 +28,13 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql:delegated
     command: --default-authentication-plugin=mysql_native_password
+    platform: linux/x86_64
   chrome:
     image: selenium/standalone-chrome:latest
     shm_size: 256m
     ports:
       - "4444:4444"
+    platform: linux/x86_64
   redis:
     image: redis:6.2.13-alpine3.18
     command: redis-server --appendonly yes
@@ -39,6 +42,7 @@ services:
       - "6379:6379"
     volumes:
       - redis-data:/var/lib/redis
+    platform: linux/x86_64
 volumes:
   mysql-data:
     driver: local

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -85,6 +85,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'spring-commands-rspec'
   gem 'webmock'
+  gem 'colorize_logs'
 end
 
 group :development do

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -69,6 +69,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'
+  gem 'colorize_logs'
   gem 'factory_bot_rails'
   gem 'graphwerk'
   gem 'launchy'
@@ -85,7 +86,6 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'spring-commands-rspec'
   gem 'webmock'
-  gem 'colorize_logs'
 end
 
 group :development do

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -184,6 +184,10 @@ GEM
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
+    colorize (1.1.0)
+    colorize_logs (0.1.0)
+      activesupport
+      colorize
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     constant_resolver (0.2.0)
@@ -675,6 +679,7 @@ DEPENDENCIES
   capybara
   carrierwave (~> 3.0)
   codecov
+  colorize_logs
   counter_culture (~> 3.5)
   devise
   devise-async

--- a/rails/app/views/brands/show.html.slim
+++ b/rails/app/views/brands/show.html.slim
@@ -1,7 +1,7 @@
 .ui.container
   .ui.grid
     .column
-      - breadcrumb :product_new
+      - breadcrumb :brand_show, @brand
       = breadcrumbs separator: " > " ,class: 'ui breadcrumb top-padding', fragment_class: 'section', current_class: 'active'
   .ui.middle.aligned.center.aligned.grid
     .column

--- a/rails/config/initializers/colorze_logs.rb
+++ b/rails/config/initializers/colorze_logs.rb
@@ -3,31 +3,21 @@
 colorize_logs_formatter = ColorizeLogs::Formatter.new
 
 colorize_logs_formatter.configure do
-  match(/Processing by/) do |msg|
-    msg.red
-  end
+  match(/Processing by/, &:red)
 
-  match(/Rendering layout/) do |msg|
-    msg.green
-  end
+  match(/Rendering layout/, &:green)
 
-  match(/Rendering.*within layouts/) do |msg|
-    msg.green
-  end
+  match(/Rendering.*within layouts/, &:green)
 
-  match(/app\/views/) do |msg|
-    msg.green
-  end
+  match(/app\/views/, &:green)
 
-  match(/Started/) do |msg|
-    msg.yellow
-  end
+  match(/Started/, &:yellow)
 
-  match(/Completed/) do |msg|
-    msg.yellow
-  end
+  match(/Completed/, &:yellow)
+
+  match(/Rendered/, &:purple)
 end
 
 if Rails.env.development?
-  ::Rails.logger.formatter = colorize_logs_formatter
+  Rails.logger.formatter = colorize_logs_formatter
 end

--- a/rails/config/initializers/colorze_logs.rb
+++ b/rails/config/initializers/colorze_logs.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+colorize_logs_formatter = ColorizeLogs::Formatter.new
+
+colorize_logs_formatter.configure do
+  match(/Processing by/) do |msg|
+    msg.red
+  end
+
+  match(/Rendering layout/) do |msg|
+    msg.green
+  end
+
+  match(/Rendering.*within layouts/) do |msg|
+    msg.green
+  end
+
+  match(/app\/views/) do |msg|
+    msg.green
+  end
+
+  match(/Started/) do |msg|
+    msg.yellow
+  end
+
+  match(/Completed/) do |msg|
+    msg.yellow
+  end
+end
+
+if Rails.env.development?
+  ::Rails.logger.formatter = colorize_logs_formatter
+end


### PR DESCRIPTION
開発環境だけログを見やすくするためのログの色をつけるジェムを追加する
テスト環境はログを特に見ない
本番環境は別のジェムを利用している

`colorize_logs`を導入

resolve #371 